### PR TITLE
Add manual override for climber limit switch

### DIFF
--- a/theRobot/src/main/java/frc/robot/RobotContainer.java
+++ b/theRobot/src/main/java/frc/robot/RobotContainer.java
@@ -172,10 +172,15 @@ public class RobotContainer {
 
       SimpleNeoMotorSubsystem climberSubsystem = subsystems.getClimberSubsystem();
 
-      climberSubsystem.setDefaultCommand(new DefaultClimberCommand(climberSubsystem,
+      climberSubsystem.setDefaultCommand(new DefaultClimberCommand(
+          climberSubsystem,
           () -> -subsystems.getManualInputInterfaces().getCoDriverLeftY()
               * subsystems.getClimberSubsystem().getMaxSpeed(),
-          () -> subsystems.getManualInputInterfaces().isCLimberLimSwitchPressed()));
+          () -> {
+            boolean limitSwitchPressed = subsystems.getManualInputInterfaces().isCLimberLimSwitchPressed();
+            boolean manualOverride = subsystems.getManualInputInterfaces().isCoDriverRightTriggerHeld();
+            return limitSwitchPressed && !manualOverride;
+          }));
       DataLogManager.log("SUCCESS: initializeClimber");
     } else {
       DataLogManager.log("FAIL: initializeClimber");

--- a/theRobot/src/main/java/frc/robot/control/ManualInputInterfaces.java
+++ b/theRobot/src/main/java/frc/robot/control/ManualInputInterfaces.java
@@ -87,6 +87,15 @@ public class ManualInputInterfaces {
         return -coDriverController.getLeftY();
     }
 
+/**
+ * Checks if the right trigger on the co-driver's controller is currently being held.
+ *
+ * @return - a boolean if the right trigger is held
+ */
+    public boolean isCoDriverRightTriggerHeld(){
+        return coDriverController.rightTrigger().getAsBoolean();
+    }
+
     /**
      * A method to return the Y value of the right joystick on the co-driver's
      * controller


### PR DESCRIPTION
Introduced a check for the co-driver's right trigger to allow manual override of the climber limit switch. Added isCoDriverRightTriggerHeld() to ManualInputInterfaces and updated the climber default command logic in RobotContainer.